### PR TITLE
Add CI that just builds the analysis

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,0 +1,26 @@
+name: Build Analysis
+
+on: [push]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout Repository
+      uses: actions/checkout@v2
+
+    - name: Pull Docker Image
+      run: docker pull cis547/cis547-base:latest
+
+    - name: Run Analysis in Docker
+      run: |
+        docker run -it -v $(pwd):/$(basename $(pwd)) -w /$(basename $(pwd)) cis547/cis547-base:latest \
+        bash -c "export LD_LIBRARY_PATH=/opt/mirtk/lib:${LD_LIBRARY_PATH} && \
+        mkdir build && cd build && \
+        cmake .. && \
+        make"
+
+    - name: Check Make Exit Status
+      run: echo $?
+

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -15,7 +15,7 @@ jobs:
 
     - name: Run Analysis in Docker
       run: |
-        docker run -it -v $(pwd):/$(basename $(pwd)) -w /$(basename $(pwd)) cis547/cis547-base:latest \
+        docker run -v $(pwd):/$(basename $(pwd)) -w /$(basename $(pwd)) cis547/cis547-base:latest \
         bash -c "export LD_LIBRARY_PATH=/opt/mirtk/lib:${LD_LIBRARY_PATH} && \
         mkdir build && cd build && \
         cmake .. && \


### PR DESCRIPTION
Once this PR is merged, every time we push to this branch, we'll get a notification if the analysis no longer builds.

In the future, we should update this to also run the tests (once they are automated).