### PR TITLE
Bug fixes for disjoint set refactor

### DIFF
--- a/Testers/Passes/double_mustcall/index.txt
+++ b/Testers/Passes/double_mustcall/index.txt
@@ -1,0 +1,1 @@
+pass=CalledMethods function=main var=s.0 methods={free,free1}

--- a/Testers/Passes/if_lub_gepinst_test/index.txt
+++ b/Testers/Passes/if_lub_gepinst_test/index.txt
@@ -1,0 +1,2 @@
+pass=CalledMethods function=main var=s.0 methods={free,free1}
+pass=CalledMethods function=main var=s.1 methods={free,free1}

--- a/Testers/Passes/struct_diff_field_aliasing_test/index.txt
+++ b/Testers/Passes/struct_diff_field_aliasing_test/index.txt
@@ -1,0 +1,2 @@
+pass=CalledMethods function=main var=s.0 methods={free}
+pass=CalledMethods function=main var=s.1 methods={free}

--- a/Testers/Passes/struct_diff_field_aliasing_test/two_structs.txt
+++ b/Testers/Passes/struct_diff_field_aliasing_test/two_structs.txt
@@ -1,0 +1,2 @@
+pass=CalledMethods function=main var=a.0 methods={free}
+pass=CalledMethods function=main var=b.1 methods={free}

--- a/include/ProgramRepresentation/PVAliasSet.h
+++ b/include/ProgramRepresentation/PVAliasSet.h
@@ -26,6 +26,10 @@ public:
   // LLVM docs: https://llvm.org/docs/LangRef.html#identifiers
   bool contains(const std::string& cleanedName);
   
+  // returns true iff there is a program var in this set with Value* value.
+  // this overload should only be used if you are looking for value that may 
+  // not exist in the branch you're currently analyzing.
+  bool contains(Value* value);
 
   // adds programVar to this set of program variables. programVar is checked to
   // see if it already exists in this set of program variables and it's not added

--- a/include/ProgramRepresentation/ProgramFunction.h
+++ b/include/ProgramRepresentation/ProgramFunction.h
@@ -38,6 +38,37 @@ public:
   ProgramPoint *getProgramPointRef(const std::string &pointName,
                                    bool addNewIfNotFound);
 
+  // searches every program point to find the alias set with that value pointer. this 
+  // method should only be used if you need access to an alias set that does not 
+  // exist in your current branch, but in a preceding one.
+  /*
+  Example situation: 
+
+  struct M {
+    char* x;
+    char* y;
+  };
+
+  int main() {
+    struct M m; 
+    m.x = (char*)malloc(15);
+    m.y = m.x;
+    [[ m.x and m.y are aliased ]]
+
+    if (getchar()) {
+      free(m.y);
+      [[ in the IR, we detect that we are 
+      referencing field y of struct M via a gepInst (effectively breaks down
+      a struct into its fields, see docs: https://llvm.org/docs/GetElementPtr.html)
+      
+      we need a ref (Value*) to that struct to build this new program variable m.y and add
+      necessary aliases. that ref is in the entry/previous program point, however. thus, 
+      to access it, we call this method. ]]
+    }
+  }
+  */
+  PVAliasSet *getPVASRefFromValue(Value* value); 
+  
   std::string getFunctionName() const;
 };
 

--- a/include/ProgramRepresentation/ProgramPoint.h
+++ b/include/ProgramRepresentation/ProgramPoint.h
@@ -61,6 +61,10 @@ public:
   // programVar. if addNewIfNotFound is false, NULL is returned
   PVAliasSet *getPVASRef(const std::string& cleanedName, bool addNewIfNotFound);
 
+  // returns a reference to the alias set if there is a set that contains a program variable with 
+  // that value pointer. this overload should only be used if you are looking for value that may 
+  // not exist in the branch you're currently analyzing. 
+  PVAliasSet *getPVASRef(Value* value, bool addNewIfNotFound);
 
   std::string getPointName() const;
 

--- a/src/Analysis.cpp
+++ b/src/Analysis.cpp
@@ -410,6 +410,15 @@ void doAliasReasoning(Instruction *instruction,
           PVAliasSet *originalStructPVASRef =
               programPoint->getPVASRef(structPV, false);
           
+          if (!originalStructPVASRef) {
+            originalStructPVASRef = programFunction.getPVASRefFromValue(pointerOperand); 
+
+            if (!originalStructPVASRef) {
+              errs() << "pvas struct ref not found by value " << *pointerOperand << ". early exit\n"; 
+              std::exit(1); 
+            }
+          }
+          
 
           ProgramFunction::logoutProgramFunction(programFunction, false);
 

--- a/src/ProgramRepresentation/DisjointedPVAliasSets.cpp
+++ b/src/ProgramRepresentation/DisjointedPVAliasSets.cpp
@@ -41,7 +41,9 @@ PVAliasSet *DisjointedPVAliasSets::getSetRef(const std::string& cleanedName) {
   return NULL;
 }
 
+PVAliasSet *DisjointedPVAliasSets::getSetRef(Value* val) {
   for (PVAliasSet &set : sets) {
+    if (set.contains(val)) {
       return &set;
     }
   }
@@ -69,16 +71,27 @@ void DisjointedPVAliasSets::makeSet(ProgramVariable programVar) {
 
 void DisjointedPVAliasSets::addAlias(ProgramVariable element1,
                                      ProgramVariable element2) {
-  for (auto it = sets.begin(); it != sets.end(); ++it) {
-    if (it->contains(element1)) {
-      it->add(element2);
-      return;
-    }
 
-    if (it->contains(element2)) {
-      it->add(element1);
-      return;
-    }
+  PVAliasSet* element1Set = this->getSetRef(element1);
+  PVAliasSet* element2Set = this->getSetRef(element2);
+  
+
+  // case: both sets exist
+  if (element1Set && element2Set) {
+    this->unionSets(element1, element2); 
+    return; 
+  }
+
+
+  // case: 1 of the sets exist
+  if (element1Set) {
+    element1Set->add(element2);
+    return; 
+  }
+
+  if (element2Set) {
+    element2Set->add(element1);
+    return; 
   }
 
 

--- a/src/ProgramRepresentation/PVAliasSet.cpp
+++ b/src/ProgramRepresentation/PVAliasSet.cpp
@@ -22,7 +22,9 @@ bool PVAliasSet::contains(const std::string& cleanedName) {
   return false;
 }
 
+bool PVAliasSet::contains(Value* value) {
   for (ProgramVariable pv : programVariables) {
+    if (pv.getValue() == value) {
       return true;
     }
   }

--- a/src/ProgramRepresentation/ProgramFunction.cpp
+++ b/src/ProgramRepresentation/ProgramFunction.cpp
@@ -65,6 +65,16 @@ void ProgramFunction::setProgramPoint(std::string name,
       programPoint.getProgramVariableAliasSets());
 }
 
+PVAliasSet *ProgramFunction::getPVASRefFromValue(Value* value) {
+  for (ProgramPoint& programPoint : programPoints) {
+    if (PVAliasSet* pvas = programPoint.getPVASRef(value, false)) {
+      return pvas; 
+    }
+  }
+
+  return NULL; 
+}
+
 void ProgramFunction::logoutProgramFunction(ProgramFunction &programFunction,
                                             bool logMethods) {
   for (auto point : programFunction.getProgramPoints()) {

--- a/src/ProgramRepresentation/ProgramPoint.cpp
+++ b/src/ProgramRepresentation/ProgramPoint.cpp
@@ -92,6 +92,13 @@ PVAliasSet *ProgramPoint::getPVASRef(const std::string& cleanedName, bool addNew
   return NULL;
 }
 
+PVAliasSet *ProgramPoint::getPVASRef(Value* value,
+                                     bool addNewIfNotFound) {
+
+  PVAliasSet *pvas = this->programVariableAliasSets.getSetRef(value);   
+
+  if (pvas) {
+    return pvas;
   }
 
   if (addNewIfNotFound) {

--- a/test/double_mustcall/index.c
+++ b/test/double_mustcall/index.c
@@ -1,0 +1,20 @@
+#include <stdio.h>
+#include <stdlib.h>
+#include <unistd.h>
+#include "../../Annotations/Annotations.h"
+
+struct M {
+    char* x MustCall("free, free1"); 
+    char* y MustCall("free"); 
+};
+
+void free1(void* p Calls("free1")) {
+    free(p);
+}
+
+int main() {   
+    struct M s; 
+
+    free(s.x);
+    free1(s.x); 
+}

--- a/test/if_lub_gepinst_test/index.c
+++ b/test/if_lub_gepinst_test/index.c
@@ -1,0 +1,35 @@
+#include <stdio.h>
+#include <stdlib.h>
+#include <unistd.h>
+#include "../../Annotations/Annotations.h"
+
+struct M {
+    char* x MustCall("free, free1"); 
+    char* y MustCall("free"); 
+};
+
+void free1(void* p Calls("free1")) {
+    free(p);
+}
+
+int main() {   
+    struct M s; 
+
+    s.x = (char*)malloc(15);
+
+    s.y = s.x; // note: when we alias s.y and s.x, the mc of the set in total will be {"free", "free1"}
+    // how does this happen? we *first* do the alias reasoning and find out s.x <-> s.y, 
+    // and then in the dataflow pass, we add the must call annotations
+    //  in the allocainst section of transfer 
+
+    // another note: the section where we auto assume mc's will be removed soon
+
+
+    free(s.x); 
+
+    if (getchar()) { 
+        free1(s.x);
+    } else {
+        free1(s.y);
+    }
+}

--- a/test/struct_diff_field_aliasing_test/index.c
+++ b/test/struct_diff_field_aliasing_test/index.c
@@ -1,0 +1,19 @@
+#include <stdio.h>
+#include <stdlib.h>
+#include <unistd.h>
+#include "../../Annotations/Annotations.h"
+
+struct M {
+    char* x MustCall("free"); 
+    char* y MustCall("free"); 
+};
+
+int main() {   
+    struct M s; 
+
+    s.x = (char*)malloc(15);
+
+    s.y = s.x;
+
+    free(s.x); 
+}

--- a/test/struct_diff_field_aliasing_test/two_structs.c
+++ b/test/struct_diff_field_aliasing_test/two_structs.c
@@ -1,0 +1,20 @@
+#include <stdio.h>
+#include <stdlib.h>
+#include <unistd.h>
+#include "../../Annotations/Annotations.h"
+
+struct M {
+    char* x MustCall("free"); 
+    char* y MustCall("free"); 
+};
+
+int main() {   
+    struct M a; 
+    struct M b;
+
+    a.x = (char*)malloc(15);
+
+    a.x = b.y; 
+
+    free(b.y); 
+}

--- a/test/unaliasing_test/index.c
+++ b/test/unaliasing_test/index.c
@@ -1,0 +1,28 @@
+#include <stdio.h>
+#include <stdlib.h>
+#include <unistd.h>
+#include "../../Annotations/Annotations.h"
+
+struct M {
+    char* x MustCall("free"); 
+    char* y MustCall("free, free1"); 
+};
+
+void free1(void* p Calls("free1")) {
+    free(p);
+}
+
+int main() {   
+    struct M s; 
+
+    s.x = (char*)malloc(15);
+
+    s.y = s.x; // aliased
+
+    s.y = (char*)malloc(15); // no longer aliased
+
+    free(s.x); // s.x freed, s.y not freed
+
+    // TODO: write test pass and implement unaliasing. note the complications with updating with proper must call's when we unalias. 
+    // and complications with the fact they are aliased at one point then unaliased 
+}


### PR DESCRIPTION
Bug 1: A struct is referenced in a different branch than the one it was defined in for certain gepInst instructions. This caused segfaults in the alias reasoning. Fixed by creating a function to search an entire program function for a certain value pointer or instruction.

Bug 2: addAlias method of DisjointedPVAliasSets did not handle case where both sets exist. This case is now explicitly handled. addAlias code also cleaner.

Additional test cases added