### PR TITLE
Bug fix regarding finding value ptr for disjoint set refactor branch

### DIFF
--- a/include/ProgramRepresentation/PVAliasSet.h
+++ b/include/ProgramRepresentation/PVAliasSet.h
@@ -26,9 +26,7 @@ class PVAliasSet {
     // LLVM docs: https://llvm.org/docs/LangRef.html#identifiers
     bool contains(const std::string& cleanedName);
 
-    // returns true iff there is a program var in this set with Value* value.
-    // this overload should only be used if you are looking for value that may
-    // not exist in the branch you're currently analyzing.
+    // returns true iff there is a program var in this set with Value* value
     bool contains(Value* value);
 
     // adds programVar to this set of program variables. programVar is checked to

--- a/include/ProgramRepresentation/PVAliasSet.h
+++ b/include/ProgramRepresentation/PVAliasSet.h
@@ -26,6 +26,10 @@ class PVAliasSet {
     // LLVM docs: https://llvm.org/docs/LangRef.html#identifiers
     bool contains(const std::string& cleanedName);
 
+    // returns true iff there is a program var in this set with Value* value.
+    // this overload should only be used if you are looking for value that may
+    // not exist in the branch you're currently analyzing.
+    bool contains(Value* value);
 
     // adds programVar to this set of program variables. programVar is checked to
     // see if it already exists in this set of program variables and it's not added

--- a/include/ProgramRepresentation/ProgramFunction.h
+++ b/include/ProgramRepresentation/ProgramFunction.h
@@ -38,7 +38,6 @@ class ProgramFunction {
     ProgramPoint *getProgramPointRef(const std::string &pointName,
                                      bool addNewIfNotFound);
 
-    // TODO: push this to separate pr
     // searches every program point to find the alias set with that value pointer. this
     // method should only be used if you need access to an alias set that does not
     // exist in your current branch, but in a preceding one.

--- a/include/ProgramRepresentation/ProgramPoint.h
+++ b/include/ProgramRepresentation/ProgramPoint.h
@@ -62,8 +62,7 @@ class ProgramPoint {
     PVAliasSet *getPVASRef(const std::string& cleanedName, bool addNewIfNotFound);
 
     // returns a reference to the alias set if there is a set that contains a program variable with
-    // that value pointer. this overload should only be used if you are looking for value that may
-    // not exist in the branch you're currently analyzing.
+    // that value pointer
     PVAliasSet *getPVASRef(Value* value, bool addNewIfNotFound);
 
     std::string getPointName() const;

--- a/include/ProgramRepresentation/ProgramPoint.h
+++ b/include/ProgramRepresentation/ProgramPoint.h
@@ -61,6 +61,10 @@ class ProgramPoint {
     // programVar. if addNewIfNotFound is false, NULL is returned
     PVAliasSet *getPVASRef(const std::string& cleanedName, bool addNewIfNotFound);
 
+    // returns a reference to the alias set if there is a set that contains a program variable with
+    // that value pointer. this overload should only be used if you are looking for value that may
+    // not exist in the branch you're currently analyzing.
+    PVAliasSet *getPVASRef(Value* value, bool addNewIfNotFound);
 
     std::string getPointName() const;
 

--- a/src/Analysis.cpp
+++ b/src/Analysis.cpp
@@ -249,8 +249,6 @@ void doAliasReasoning(Instruction *instruction,
         realBranchOrder.push_back(branchName);
     }
 
-    // TODO: add bug fix to new pr
-
     if (LoadInst *load = dyn_cast<LoadInst>(instruction)) {
         logout("(load) name is " << variable(load) << " for "
                << variable(load->getPointerOperand()));

--- a/src/ProgramRepresentation/DisjointedPVAliasSets.cpp
+++ b/src/ProgramRepresentation/DisjointedPVAliasSets.cpp
@@ -43,6 +43,15 @@ PVAliasSet *DisjointedPVAliasSets::getSetRef(const std::string& cleanedName) {
     return NULL;
 }
 
+PVAliasSet *DisjointedPVAliasSets::getSetRef(Value* val) {
+    for (PVAliasSet &set : sets) {
+        if (set.contains(val)) {
+            return &set;
+        }
+    }
+
+    return NULL;
+}
 
 void DisjointedPVAliasSets::unionSets(ProgramVariable elementA,
                                       ProgramVariable elementB) {

--- a/src/ProgramRepresentation/PVAliasSet.cpp
+++ b/src/ProgramRepresentation/PVAliasSet.cpp
@@ -28,6 +28,8 @@ bool PVAliasSet::contains(Value* value) {
             return true;
         }
     }
+
+    return false;
 }
 
 void PVAliasSet::add(ProgramVariable programVar) {

--- a/src/ProgramRepresentation/PVAliasSet.cpp
+++ b/src/ProgramRepresentation/PVAliasSet.cpp
@@ -22,7 +22,13 @@ bool PVAliasSet::contains(const std::string& cleanedName) {
     return false;
 }
 
-// TODO: diff pr for bool PVAliasSet::contains(Value* value)
+bool PVAliasSet::contains(Value* value) {
+    for (ProgramVariable pv : programVariables) {
+        if (pv.getValue() == value) {
+            return true;
+        }
+    }
+}
 
 void PVAliasSet::add(ProgramVariable programVar) {
     if (contains(programVar)) {

--- a/src/ProgramRepresentation/ProgramPoint.cpp
+++ b/src/ProgramRepresentation/ProgramPoint.cpp
@@ -94,8 +94,23 @@ PVAliasSet *ProgramPoint::getPVASRef(const std::string& cleanedName, bool addNew
     return NULL;
 }
 
-// TODO: diff pr for PVAliasSet *ProgramPoint::getPVASRef(Value* value,
-//  bool addNewIfNotFound)
+PVAliasSet *ProgramPoint::getPVASRef(Value* value,
+                                     bool addNewIfNotFound) {
+
+    PVAliasSet *pvas = this->programVariableAliasSets.getSetRef(value);
+
+    if (pvas) {
+        return pvas;
+    }
+
+    if (addNewIfNotFound) {
+        ProgramVariable newPV = ProgramVariable(value);
+        this->addVariable(newPV);
+        return &this->programVariableAliasSets.sets.back();
+    }
+
+    return NULL;
+}
 
 bool ProgramPoint::equals(ProgramPoint *programPoint) {
     for (PVAliasSet set : this->programVariableAliasSets.sets) {


### PR DESCRIPTION
Bug desc: A struct is referenced in a different branch than the one it was defined in for certain gepInst instructions. This caused segfaults in the alias reasoning. Fixed by creating a function to search an entire program function for a certain value pointer or instruction.