### PR TITLE
Adds temp file manager

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -33,6 +33,7 @@ add_llvm_library(CodeAnalyzer MODULE
   src/DataflowPass.cpp
   src/TestRunner.cpp
   src/StructFieldToIndexMap.cpp
+  src/TempFileManager.cpp
   src/Analysis.cpp
   src/RunAnalysis.cpp
   src/Utils.cpp

--- a/include/StructFieldToIndexMap.h
+++ b/include/StructFieldToIndexMap.h
@@ -2,6 +2,7 @@
 #define STRUCT_FIELD_TO_INDEX_H
 
 #include "Utils.h"
+#include "TempFileManager.h"
 
 /*
 string map between struct var name + struct field to struct name + struct index.
@@ -38,7 +39,8 @@ class StructFieldToIndexMap {
   public:
     StructFieldToIndexMap();
 
-    void buildMap(const std::string& optLoadFileName);
+    // builds the map based off a tmp file which consists of the AST of a C program
+    void buildMap(const TempFileManager& astFile);
 
     // returns the corresponding struct name and index based on structNameAndField
     std::string get(const std::string& structNameAndField);

--- a/include/TempFileManager.h
+++ b/include/TempFileManager.h
@@ -1,0 +1,34 @@
+#ifndef TMP_FILE_MANAGER_H
+#define TMP_FILE_MANAGER_H
+
+#include "Utils.h"
+
+// handles creating a temp file and unlinking it upon destruction
+class TempFileManager {
+  private:
+    std::string tempFileName;
+    int tempFileFD;
+
+  public:
+    // creates a temp file and directory based off fileName.
+    // the internal temp file name will differ from fileName.
+    TempFileManager(const std::string& fileName);
+
+    ~TempFileManager();
+
+    // returns the generated file name
+    std::string getFileName() const;
+
+    // generates a new file stream for the temp file
+    std::ifstream getFileStream() const;
+};
+
+namespace tempfile_util {
+
+// generates the AST of the C program referenced by optLoadFileName and dumps
+// its content into tmp
+void dumpASTIntoTempFile(const std::string& optLoadFileName, TempFileManager& tmp);
+
+}
+
+#endif

--- a/src/TempFileManager.cpp
+++ b/src/TempFileManager.cpp
@@ -1,0 +1,45 @@
+#include "TempFileManager.h"
+#include "Debug.h"
+
+TempFileManager::TempFileManager(const std::string& fileName) {
+    tempFileName = "/tmp/" + std::string(fileName) + "XXXXXX";
+
+    char *tempFileFDChar = new char[tempFileName.length() + 1];
+    strcpy(tempFileFDChar, tempFileName.c_str());
+
+    tempFileFD = mkstemp(tempFileFDChar);
+
+    tempFileName = std::string(tempFileFDChar);
+
+    delete[] tempFileFDChar;
+
+    if (tempFileFD == -1) {
+        logout("failed to create temp file '" << fileName << "'");
+        perror("mkstemp");
+        exit(1);
+    }
+}
+
+std::string TempFileManager::getFileName() const {
+    return tempFileName;
+}
+
+std::ifstream TempFileManager::getFileStream() const {
+    return std::ifstream(tempFileName);
+}
+
+TempFileManager::~TempFileManager() {
+    close(tempFileFD);
+    unlink(tempFileName.c_str());
+}
+
+namespace tempfile_util {
+
+void dumpASTIntoTempFile(const std::string& optLoadFileName, TempFileManager& tmp) {
+    std::string dumpASTCommand =
+        "clang -Xclang -ast-dump -fsyntax-only -fno-color-diagnostics " +
+        optLoadFileName + "> " + tmp.getFileName();
+    system(dumpASTCommand.c_str());
+}
+
+}


### PR DESCRIPTION
temp file manager is used to simplify the process of creating AST on the user end. we can use it to generate only one AST and pass it around as needed. here, we need the AST for `getAnnotationStrings` and for the `StructFieldToIndexMap`