### PR TITLE
Bug fix: detecting multiple annotations on one parameter

### DIFF
--- a/Testers/Passes/call_all_small_test/call_2.txt
+++ b/Testers/Passes/call_all_small_test/call_2.txt
@@ -1,0 +1,4 @@
+pass=MustCall function=main var=test.a methods={free}
+pass=MustCall function=main var=test.b methods={free}
+pass=CalledMethods function=main var=test.a methods={calls_all,free}
+pass=CalledMethods function=main var=test.b methods={calls_all,free}

--- a/include/DataflowPass.h
+++ b/include/DataflowPass.h
@@ -70,8 +70,7 @@ class DataflowPass {
 
     // a helper function that checks for parameter annotations on call
     // instructions. returns true if an annotation was found, and false if not.
-    bool handleIfAnnotationExistsForCallInsts(const std::string &fnName,
-            int argIndex, PVAliasSet *pvas);
+    bool handleIfAnnotationExistsForCallInsts(const std::string &fnName, CallInst* call, PVAliasSet *pvas);
 
   protected:
     ProgramFunction programFunction;

--- a/test/call_all_small_test/call_2.c
+++ b/test/call_all_small_test/call_2.c
@@ -14,10 +14,10 @@ void calls_all(my_struct S Calls("free", "a") Calls("free", "b")) {
 }
 
 int main() {
-    my_struct test; 
+    my_struct test;
     test.a = (char*)malloc(15);
     test.b = (char*)malloc(15);
     calls_all(test);
 
-    return 0; 
+    return 0;
 }

--- a/test/call_all_small_test/call_2.c
+++ b/test/call_all_small_test/call_2.c
@@ -1,0 +1,23 @@
+#include <stdio.h>
+#include <stdlib.h>
+#include <unistd.h>
+#include "../../Annotations/Annotations.h"
+
+typedef struct my_struct {
+    char* a MustCall("free");
+    char* b MustCall("free");
+} my_struct;
+
+void calls_all(my_struct S Calls("free", "a") Calls("free", "b")) {
+    free(S.a);
+    free(S.b);
+}
+
+int main() {
+    my_struct test; 
+    test.a = (char*)malloc(15);
+    test.b = (char*)malloc(15);
+    calls_all(test);
+
+    return 0; 
+}


### PR DESCRIPTION
Bug description: On structs with a small number of fields (typically 1 or 2), the LLVM IR destructures them into their elements. This conflicts with how parameters do not do this destructuring, making it so we would miss out on annotations on parameters with more than 1 annotation

Bug fix: iterate to find all possible parameter specifications, instead of just a singular index (`argIndex`)

The branch name specifies "small struct" because the IR does not destructure it when there many fields to the struct, causing it to pass it in with a byval attribute (see docs: https://llvm.org/docs/LangRef.html#parameter-attributes) or sret attribute (handled with DataflowPass::handleSretCallForCallInsts) 

This code does not fix it when it's passed in with byval, but the fix will be implemented in branch `multi-anno-one-param-fix` 

