### PR TITLE
Bug fix on certain field type

### DIFF
--- a/TestHelpers/struct_field_to_index_map_generator.py
+++ b/TestHelpers/struct_field_to_index_map_generator.py
@@ -183,9 +183,10 @@ def parse_var_decl(var_decl: str, struct_var_manager_holder: StructVarManager, s
 
     struct_name_split = struct_name.split(" ")
 
-    # check if type is formatted like 'my_struct *' (typedef alias in use) 
+    # check if type is formatted like 'my_struct *' (typedef alias in use)
     # instead of 'struct my_struct *' (no typedef alias in use)
-    type_formatted_using_typedef = len(struct_name_split) > 1 and "*" in struct_name_split
+    type_formatted_using_typedef = len(
+        struct_name_split) > 1 and "*" in struct_name_split
 
     if len(struct_name_split) == 2 and "*" in struct_name_split[1]:
         struct_name = struct_name_split[0]


### PR DESCRIPTION
Field type that were declared using typedef alias were being parsed incorrectly by field-to-index map. Now fixed 

Note: it is known we need a testing framework for the struct field to index map to prove something was actually fixed. But consider that this is a pr for a bug fix for a pr for a bug fix. 