### PR TITLE
Prevents duplicate parameter from appearing

### DIFF
--- a/ASTAnalyses/ASTInfo/Specifiers/FunctionStructure/Function.py
+++ b/ASTAnalyses/ASTInfo/Specifiers/FunctionStructure/Function.py
@@ -27,7 +27,7 @@ class Function(Specifier):
         for param in self.__parameters:
             if param.get_index() == parameter.get_index():
                 return
-        
+
         self.__parameters.append(parameter)
 
     def equals(self, function_name: str):

--- a/ASTAnalyses/ASTInfo/Specifiers/FunctionStructure/Function.py
+++ b/ASTAnalyses/ASTInfo/Specifiers/FunctionStructure/Function.py
@@ -24,6 +24,10 @@ class Function(Specifier):
         self.return_type = return_type
 
     def add_parameter(self, parameter: Parameter) -> None:
+        for param in self.__parameters:
+            if param.get_index() == parameter.get_index():
+                return
+        
         self.__parameters.append(parameter)
 
     def equals(self, function_name: str):


### PR DESCRIPTION
It was possible that a function's parameters could repeat twice. E.g., for function `char* do_thing(a, b, c)`, after it's decompressed by the AST and read again by our analysis, the function declaration for it may appear several times, alongside its parameter declarations. The function would thus appear to have parameters a, b, c, a, b, c. 

This change makes it so the function would only have parameters a, b, c. 

Note: I know there is no evidence that this claim is true, but this will be the case once testing for the AST passes is implemented. This change is needed for the development of the function-info-pass branch. 