### PR TITLE
Bug fix to StructFieldToIndexMap

### DIFF
--- a/src/StructFieldToIndexMap.cpp
+++ b/src/StructFieldToIndexMap.cpp
@@ -50,5 +50,5 @@ std::string StructFieldToIndexMap::get(const std::string& structNameAndField) {
 }
 
 bool StructFieldToIndexMap::structNameAndFieldIsInMap(const std::string& structNameAndField) {
-    return this->fieldToIndexMap.count(structNameAndField);
+    return this->fieldToIndexMap.count(structNameAndField) && this->fieldToIndexMap[structNameAndField] != "";
 }


### PR DESCRIPTION
Ensures empty string is not returned. This was found to be necessary during the development of un-aliasing-impl branch. Testing for StructFieldToIndexMap will be added soon to verify that this bug fix does something