### PR TITLE
Branch order bug fix

### DIFF
--- a/src/Analysis.cpp
+++ b/src/Analysis.cpp
@@ -598,6 +598,8 @@ void CodeAnalyzer::doAnalysis(Function &F, std::string optLoadFileName) {
     } else {
         logout("BRANCH LISTER TESTER PASSED");
     }
+
+    realBranchOrder.clear();
 }
 
 // utilFunctionTester is an extended class of UtilFunctionTester


### PR DESCRIPTION
Bug was found (during development of more branch lister tests) where the real branch order of one function carried on to be the branch order of another unrelated function. Patched by clearing the real branch order after running each function 