### PR TITLE
Adds testing for Function Info + Tweaks to DeclParser logic

### DIFF
--- a/ASTAnalyses/ASTInfo/DeclParser/DeclParser.py
+++ b/ASTAnalyses/ASTInfo/DeclParser/DeclParser.py
@@ -73,6 +73,8 @@ class DeclParser:
             return_type = return_type[:len(return_type) - 1]
 
         # if return type looks like "int *", change it to "int*"
+        # or if it looks like "int **", change it to "int**"
+        # (we assume asterisks are grouped together)
         potential_space_char_index = return_type.find("*") - 1
         if return_type[len(return_type) - 1] == "*" and return_type[potential_space_char_index] == " ":
             return_type = return_type[:potential_space_char_index] + \

--- a/ASTAnalyses/ASTInfo/DeclParser/DeclParser.py
+++ b/ASTAnalyses/ASTInfo/DeclParser/DeclParser.py
@@ -61,12 +61,22 @@ class DeclParser:
             # e.g., 'int ()' is a function that returns int with no parameters
 
             # e.g., 'void (int, int, char *)' is a function that returns void with
-            # 3 parameters (in the order as it appears in C code), int, int, and char *
+            # 3 parameters (in the order as it appears in C code), int, int, and char*
 
             return_type += cur_char
 
             start_index += 1
             cur_char = function_decl[start_index]
+
+        # if return type looks like "int ", change it to "int"
+        if return_type[len(return_type) - 1] == " ":
+            return_type = return_type[:len(return_type) - 1]
+
+        # if return type looks like "int *", change it to "int*"
+        potential_space_char_index = return_type.find("*") - 1
+        if return_type[len(return_type) - 1] == "*" and return_type[potential_space_char_index] == " ":
+            return_type = return_type[:potential_space_char_index] + \
+                return_type[potential_space_char_index + 1:]
 
         logout(
             f"function name = '{function_name}', return type = '{return_type}'")
@@ -101,8 +111,11 @@ class DeclParser:
             param_type = param_type[: param_type.find("'")]
 
         logout(f"'{param_type}'")
-        if "*" in param_type:
-            param_type = param_type.replace(" ", "").replace("*", "")
+
+        potential_space_char_index = param_type.find("*") - 1
+        if param_type[len(param_type) - 1] == "*" and param_type[potential_space_char_index] == " ":
+            param_type = param_type[:potential_space_char_index] + \
+                param_type[potential_space_char_index + 1:]
         else:
             # param_type might look like "my_struct " or "struct my_struct"
             if param_type[-1] == " ":
@@ -293,7 +306,7 @@ class DeclParser:
                     # we'll throw "ValueError: Did not find field 'x' for struct 'int', anno Calls target = _.FIELD(x) methods = free"
 
                     return_type_split = spec.get_return_type().split(" ")
-                    if return_type_split[1] != "":
+                    if len(return_type_split) > 1 and return_type_split[1] != "":
                         return_struct_name = return_type_split[1]
                     else:
                         return_struct_name = return_type_split[0]
@@ -326,6 +339,10 @@ class DeclParser:
                                     1]
                             except IndexError:
                                 param_type_struct_name = param.get_param_type()
+
+                            # removes "*" only for searching purposes
+                            param_type_struct_name = param_type_struct_name.replace(
+                                "*", "")
 
                             struct = specifier_manager.get_or_add_struct(
                                 param_type_struct_name)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -49,6 +49,7 @@ add_llvm_library(CodeAnalyzer MODULE
   src/TestRunner.cpp
   src/BranchListerTester.cpp
   src/StructFieldToIndexTester.cpp
+  src/FunctionInfoTester.cpp
   src/StructFieldToIndexMap.cpp
   src/TempFileManager.cpp
   src/FunctionInfo.cpp

--- a/Testers/FunctionInfo/call_all_small_test/call_2.txt
+++ b/Testers/FunctionInfo/call_all_small_test/call_2.txt
@@ -1,0 +1,2 @@
+function=calls_all|return=void|params={struct my_struct}
+function=main|return=int|params={}

--- a/Testers/FunctionInfo/double_mustcall/index.txt
+++ b/Testers/FunctionInfo/double_mustcall/index.txt
@@ -1,0 +1,2 @@
+function=free1|return=void|params={void*}
+function=main|return=int|params={}

--- a/Testers/FunctionInfo/if_lub_test/index.txt
+++ b/Testers/FunctionInfo/if_lub_test/index.txt
@@ -1,0 +1,2 @@
+function=free1|return=void|params={void*}
+function=main|return=int|params={}

--- a/Testers/FunctionInfo/includes_test/call_structs.txt
+++ b/Testers/FunctionInfo/includes_test/call_structs.txt
@@ -1,0 +1,4 @@
+function=does_free|return=void|params={char*}
+function=creates_obligation|return=char*|params={char*,struct my_struct}
+function=does_something|return=struct my_struct|params={struct my_struct}
+function=main|return=int|params={}

--- a/Testers/FunctionInfo/includes_test/subdir/runner.txt
+++ b/Testers/FunctionInfo/includes_test/subdir/runner.txt
@@ -1,0 +1,4 @@
+function=does_free|return=void|params={char*}
+function=creates_obligation|return=char*|params={char*,struct my_struct}
+function=does_something|return=struct my_struct|params={struct my_struct}
+function=main|return=int|params={}

--- a/Testers/FunctionInfo/long_struct/index.txt
+++ b/Testers/FunctionInfo/long_struct/index.txt
@@ -1,0 +1,5 @@
+function=does_something_a|return=struct my_struct|params={struct my_struct}
+function=does_something_b|return=struct my_struct|params={struct my_struct}
+function=does_something_c|return=struct my_struct|params={struct my_struct}
+function=does_something_d|return=struct my_struct|params={int,struct my_struct,struct my_struct,int,char*}
+function=main|return=int|params={}

--- a/Testers/FunctionInfo/ptr_struct_alloc/index.txt
+++ b/Testers/FunctionInfo/ptr_struct_alloc/index.txt
@@ -1,0 +1,2 @@
+function=does_free_one_pointer|return=void|params={struct my_struct*}
+function=main|return=int|params={}

--- a/Testers/FunctionInfo/ptr_struct_param/index.txt
+++ b/Testers/FunctionInfo/ptr_struct_param/index.txt
@@ -1,0 +1,4 @@
+function=struct_no_ptr_params|return=void|params={struct my_struct}
+function=does_free_one_pointer|return=void|params={struct my_struct}
+function=absurd_pointer|return=void|params={struct my_struct****}
+function=main|return=int|params={}

--- a/Testers/FunctionInfo/recover_desugar/main.txt
+++ b/Testers/FunctionInfo/recover_desugar/main.txt
@@ -1,0 +1,3 @@
+function=does_free|return=void|params={char*}
+function=does_something|return=struct my_struct|params={struct my_struct}
+function=main|return=int|params={}

--- a/Testers/FunctionInfo/return_anno/index.txt
+++ b/Testers/FunctionInfo/return_anno/index.txt
@@ -1,0 +1,3 @@
+function=return_calls_free|return=char*|params={char*}
+function=return_calls_free_on_struct|return=struct my_struct|params={struct my_struct}
+function=main|return=int|params={}

--- a/Testers/FunctionInfo/simple_anno_test/index.txt
+++ b/Testers/FunctionInfo/simple_anno_test/index.txt
@@ -1,0 +1,3 @@
+function=malloc0|return=void*|params={size_t}
+function=free0|return=void|params={void*}
+function=main|return=int|params={}

--- a/Testers/FunctionInfo/simple_anno_test2/index.txt
+++ b/Testers/FunctionInfo/simple_anno_test2/index.txt
@@ -1,0 +1,3 @@
+function=does_malloc|return=void|params={char*}
+function=does_free|return=void|params={char*}
+function=main|return=int|params={}

--- a/Testers/FunctionInfo/simple_anno_test3/index.txt
+++ b/Testers/FunctionInfo/simple_anno_test3/index.txt
@@ -1,0 +1,2 @@
+function=does_free|return=void|params={char*,char*}
+function=main|return=int|params={}

--- a/Testers/FunctionInfo/test10/test10.txt
+++ b/Testers/FunctionInfo/test10/test10.txt
@@ -1,0 +1,9 @@
+function=malloc0|return=void*|params={size_t}
+function=malloc1|return=void*|params={size_t}
+function=malloc2|return=void*|params={size_t}
+function=malloc3|return=void*|params={size_t}
+function=free0|return=void|params={void*}
+function=free1|return=void|params={void*}
+function=free2|return=void|params={void*}
+function=free3|return=void|params={void*}
+function=main|return=int|params={}

--- a/Testers/FunctionInfo/test11/test11.txt
+++ b/Testers/FunctionInfo/test11/test11.txt
@@ -1,0 +1,9 @@
+function=malloc0|return=void*|params={size_t}
+function=malloc1|return=void*|params={size_t}
+function=malloc2|return=void*|params={size_t}
+function=malloc3|return=void*|params={size_t}
+function=free0|return=int|params={void*}  
+function=free1|return=int|params={void*}
+function=free2|return=int|params={void*}
+function=free3|return=int|params={void*}
+function=main|return=int|params={}

--- a/Testers/FunctionInfo/test12/test12.txt
+++ b/Testers/FunctionInfo/test12/test12.txt
@@ -1,0 +1,9 @@
+function=malloc0|return=void*|params={size_t}
+function=malloc1|return=void*|params={size_t}
+function=malloc2|return=void*|params={size_t}
+function=malloc3|return=void*|params={size_t}
+function=free0|return=int|params={void*}
+function=free1|return=int|params={void*}
+function=free2|return=int|params={void*}
+function=free3|return=int|params={void*}
+function=main|return=int|params={}

--- a/Testers/FunctionInfo/test16/test16.txt
+++ b/Testers/FunctionInfo/test16/test16.txt
@@ -1,0 +1,5 @@
+function=does_free|return=void|params={char*}
+function=creates_obligation|return=char*|params={char*,struct my_struct}
+function=does_something|return=struct my_struct|params={struct my_struct}
+function=does_something_simpler|return=char*|params={char*}
+function=main|return=int|params={}

--- a/Testers/FunctionInfo/test2/test2.txt
+++ b/Testers/FunctionInfo/test2/test2.txt
@@ -1,0 +1,2 @@
+function=unknown_function|return=void|params={char*}
+function=main|return=int|params={}

--- a/Testers/FunctionInfo/test3/test3.txt
+++ b/Testers/FunctionInfo/test3/test3.txt
@@ -1,0 +1,2 @@
+function=strcpy|return=char*|params={char*,const char*}
+function=main|return=int|params={}

--- a/Testers/FunctionInfo/test7/test7.txt
+++ b/Testers/FunctionInfo/test7/test7.txt
@@ -1,0 +1,9 @@
+function=malloc0|return=void*|params={size_t}
+function=malloc1|return=void*|params={size_t}
+function=malloc2|return=void*|params={size_t}
+function=malloc3|return=void*|params={size_t}
+function=free0|return=void|params={void*}
+function=free1|return=void|params={void*}
+function=free2|return=void|params={void*}
+function=free3|return=void|params={void*}
+function=main|return=int|params={}

--- a/Testers/FunctionInfo/test8/test8.txt
+++ b/Testers/FunctionInfo/test8/test8.txt
@@ -1,0 +1,9 @@
+function=malloc0|return=void*|params={size_t}
+function=malloc1|return=void*|params={size_t}
+function=malloc2|return=void*|params={size_t}
+function=malloc3|return=void*|params={size_t}
+function=free0|return=void|params={void*}
+function=free1|return=void|params={void*}
+function=free2|return=void|params={void*}
+function=free3|return=void|params={void*}
+function=main|return=int|params={}

--- a/Testers/FunctionInfo/test9/test9.txt
+++ b/Testers/FunctionInfo/test9/test9.txt
@@ -1,0 +1,9 @@
+function=malloc0|return=void*|params={size_t}
+function=malloc1|return=void*|params={size_t}
+function=malloc2|return=void*|params={size_t}
+function=malloc3|return=void*|params={size_t}
+function=free0|return=void|params={void*}
+function=free1|return=void|params={void*}
+function=free2|return=void|params={void*}
+function=free3|return=void|params={void*}
+function=main|return=int|params={}

--- a/Testers/FunctionInfo/unaliasing_test/index.txt
+++ b/Testers/FunctionInfo/unaliasing_test/index.txt
@@ -1,0 +1,2 @@
+function=free1|return=void|params={void*}
+function=main|return=int|params={}

--- a/include/Constants.h
+++ b/include/Constants.h
@@ -14,6 +14,7 @@ const std::string LLVM_VAR_ANNOTATION = "llvm.var.annotation";
 const std::string PASS_TEST_DIRNAME = "../Testers/Passes";
 const std::string BRANCH_LISTER_TEST_DIRNAME = "../Testers/BranchLister";
 const std::string STRUCT_FIELD_TO_INDEX_TEST_DIRNAME = "../Testers/StructFieldToIndex";
+const std::string FUNCTION_INFO_TEST_DIRNAME = "../Testers/FunctionInfo";
 
 const std::string AST_ANNO_PASS_LOCATION = "../ASTAnalyses/ASTPasses/AnnotationPass/anno_pass.py";
 const std::string AST_INFO_GENERATOR_LOCATION = "../ASTAnalyses/ASTInfo/generator.py";

--- a/include/Debug.h
+++ b/include/Debug.h
@@ -3,7 +3,7 @@
 #define DEBUG true
 #define UTIL_VARIABLE_FUNC_DEBUG false
 #define BUILD_PROGRAM_LINES_BRANCH_INFO false
-#define RUN_UTIL_FUNCTION_TESTS false
+#define RUN_UTIL_FUNCTION_TESTS true
 
 #if DEBUG
 #define logout(x) errs() << x << "\n"

--- a/include/Debug.h
+++ b/include/Debug.h
@@ -3,7 +3,7 @@
 #define DEBUG true
 #define UTIL_VARIABLE_FUNC_DEBUG false
 #define BUILD_PROGRAM_LINES_BRANCH_INFO false
-#define RUN_UTIL_FUNCTION_TESTS true
+#define RUN_UTIL_FUNCTION_TESTS false
 
 #if DEBUG
 #define logout(x) errs() << x << "\n"

--- a/include/FunctionInfoTester.h
+++ b/include/FunctionInfoTester.h
@@ -1,0 +1,12 @@
+#ifndef FUNCTION_INFO_TESTER_H
+#define FUNCTION_INFO_TESTER_H
+
+#include "FunctionInfosManager.h"
+
+class FunctionInfoTester {
+  public:
+    // returns EXIT_SUCCESS if tests passed and EXIT_FAILURE if failed
+    static bool runTest(const std::string& testName, FunctionInfosManager& functionInfosManager);
+};
+
+#endif

--- a/src/Analysis.cpp
+++ b/src/Analysis.cpp
@@ -548,13 +548,6 @@ void CodeAnalyzer::doAnalysis(Function &F, std::string optLoadFileName) {
         }
     }
 
-    if (auto f = functionInfosManager.getFunction(fnName)) {
-        logout("got ret type '" << f->getReturnType() << "' for " << fnName);
-        for (int i = 0; i < f->getNumberOfParameters(); i++) {
-            logout(i << ": '" << f->getNthParamType(i) << "'");
-        }
-    }
-
     CFG cfg;
     buildCFG(cfg, realBranchOrder, branchInstructionMap);
 

--- a/src/Analysis.cpp
+++ b/src/Analysis.cpp
@@ -33,6 +33,7 @@
 #include "TestRunner.h"
 #include "BranchListerTester.h"
 #include "StructFieldToIndexTester.h"
+#include "FunctionInfoTester.h"
 #include "TempFileManager.h"
 #include "FunctionInfosManager.h"
 #include "Utils.h"
@@ -547,6 +548,13 @@ void CodeAnalyzer::doAnalysis(Function &F, std::string optLoadFileName) {
         }
     }
 
+    if (auto f = functionInfosManager.getFunction(fnName)) {
+        logout("got ret type '" << f->getReturnType() << "' for " << fnName);
+        for (int i = 0; i < f->getNumberOfParameters(); i++) {
+            logout(i << ": '" << f->getNthParamType(i) << "'");
+        }
+    }
+
     CFG cfg;
     buildCFG(cfg, realBranchOrder, branchInstructionMap);
 
@@ -608,6 +616,13 @@ void CodeAnalyzer::doAnalysis(Function &F, std::string optLoadFileName) {
         logout("STRUCT FIELD TO INDEX TESTER PASSED");
     }
 
+    if (FunctionInfoTester::runTest(testName, functionInfosManager) == EXIT_FAILURE) {
+        logout("**FUNCTION INFO TESTER FAILED");
+        anyTestFailed = true;
+    } else {
+        logout("FUNCTION INFO TESTER PASSED");
+    }
+    
     realBranchOrder.clear();
 }
 

--- a/src/Analysis.cpp
+++ b/src/Analysis.cpp
@@ -615,7 +615,7 @@ void CodeAnalyzer::doAnalysis(Function &F, std::string optLoadFileName) {
     } else {
         logout("FUNCTION INFO TESTER PASSED");
     }
-    
+
     realBranchOrder.clear();
 }
 

--- a/src/FunctionInfoTester.cpp
+++ b/src/FunctionInfoTester.cpp
@@ -1,0 +1,91 @@
+#include "FunctionInfoTester.h"
+#include "Constants.h"
+#include "Utils.h"
+#include "Debug.h"
+
+bool FunctionInfoTester::runTest(const std::string& testName, FunctionInfosManager& functionInfosManager) {
+    bool testPassed = EXIT_SUCCESS;
+    std::ifstream testFile(FUNCTION_INFO_TEST_DIRNAME + "/" + testName + ".txt");
+    std::string line;
+
+    if (testFile.is_open()) {
+        while (std::getline(testFile, line)) {
+            // test arguments are written in one line and can be put in any order.
+            // they look like the following:
+            // function=<str>|return=<str>|params=<set<str>>
+            // e.g., function=malloc0|return=void*|params={size_t,int}.
+            // if the parameter or return type is a struct,
+            // it must be specified with "struct <struct_name>"
+            // (because the function info pass may return some struct M as either
+            // "M" or "struct M")
+
+            std::string functionName, returnType;
+            std::vector<std::string> params;
+
+            std::vector<std::string> arguments = rlc_util::splitString(line, '|');
+            for (std::string arg : arguments) {
+                std::vector<std::string> argChunks = rlc_util::splitString(arg, '=');
+
+                if (argChunks.size() != 2) {
+                    logout("**FUNCTION INFO TESTER ERROR: Too few or too many pipes (|) in argument '" << arg << "' on line '" << line << "'");
+                    std::exit(EXIT_FAILURE);
+                }
+
+                std::string type = argChunks[0];
+                std::string input = argChunks[1];
+
+                if (type == "function") {
+                    functionName = input;
+                } else if (type == "return") {
+                    returnType = input;
+                } else if (type == "params") {
+                    params = rlc_util::splitString(
+                                 rlc_util::sliceString(input, input.find('{') + 1,
+                                                       input.find('}') - 1),
+                                 ',');
+                } else {
+                    logout("**FUNCTION INFO TESTER ERROR: Unrecognized argument '" << type << "' on line '" << line << "'");
+                    std::exit(EXIT_FAILURE);
+                }
+            }
+
+            if (functionName == "") {
+                logout("**FUNCTION INFO TESTER ERROR: Function name argument missing on line '" << line << "'");
+                std::exit(EXIT_FAILURE);
+            }
+
+            if (returnType == "") {
+                logout("**FUNCTION INFO TESTER ERROR: Return type argument missing on line '" << line << "'");
+                std::exit(EXIT_FAILURE);
+            }
+
+            if (auto receivedFunction = functionInfosManager.getFunction(functionName)) {
+
+                if (receivedFunction->getReturnType() != returnType &&
+                        "struct " + receivedFunction->getReturnType() != returnType) {
+                    logout("**FUNCTION INFO TESTER ERROR: expected return type '" << returnType << "' but received '"  << receivedFunction->getReturnType() << "'");
+                    testPassed = EXIT_FAILURE;
+                }
+
+                if (receivedFunction->getNumberOfParameters() != params.size()) {
+                    logout("**FUNCTION INFO TESTER ERROR: Received number of params not equal to expected number of params for function '" << functionName << "'");
+                } else {
+                    for (unsigned i = 0; i < receivedFunction->getNumberOfParameters(); i++) {
+                        if (receivedFunction->getNthParamType(i) != params[i] &&
+                                "struct " + receivedFunction->getNthParamType(i) != params[i]) {
+                            logout("**FUNCTION INFO TESTER ERROR: Parameter " << i << " mismatch: expected '" << params[i] << "' but received '" << receivedFunction->getNthParamType(i) << "'");
+                            testPassed = EXIT_FAILURE;
+                        }
+                    }
+                }
+            } else {
+                logout("**FUNCTION INFO TESTER ERROR: Did not find function info for function '" << functionName << "'");
+                testPassed = EXIT_FAILURE;
+            }
+        }
+    }
+
+    testFile.close();
+
+    return testPassed;
+}


### PR DESCRIPTION
Tweaks made to DeclParser are so that the testing for Function Info adheres to a certain format