### PR TITLE
Fix to function info test

### DIFF
--- a/Testers/FunctionInfo/unaliasing_test/index.txt
+++ b/Testers/FunctionInfo/unaliasing_test/index.txt
@@ -1,2 +1,1 @@
-function=free1|return=void|params={void*}
 function=main|return=int|params={}


### PR DESCRIPTION
A FI test requested function info for a function that did not exist in the corresponding C file. This change fixes that. This likely ended up in the FI test from a copy-paste error